### PR TITLE
Add CTAD for __mstring

### DIFF
--- a/include/stdexec/__detail/__meta.hpp
+++ b/include/stdexec/__detail/__meta.hpp
@@ -159,6 +159,9 @@ namespace stdexec {
     char const __what_[_Len];
   };
 
+  template <std::size_t _Len>
+  __mstring(const char (&__str)[_Len]) -> __mstring<_Len>;
+
   STDEXEC_PRAGMA_PUSH()
   STDEXEC_PRAGMA_IGNORE_GNU("-Wuser-defined-literals")
 


### PR DESCRIPTION
This cleans up build warnings about missing CTAD.